### PR TITLE
feat(datasets): add enhanced rendering pipeline for dataset_1 with hierarchical sections

### DIFF
--- a/src/components/DatasetAndReleaseNotes.tsx
+++ b/src/components/DatasetAndReleaseNotes.tsx
@@ -59,7 +59,7 @@ const DatasetAndReleaseNotes: FC<{ releases: GitHubRelease[], datasets: GitHubDa
       <section className="flex relative flex-col gap-1.5 items-center self-stretch bg-sky-50 border-b border-solid border-b-cyan-600 h-[88px] max-sm:h-auto">
         <div className="flex relative flex-col gap-1.5 justify-end items-start self-stretch max-w-[1260px] mx-30 max-sm:mx-5">
           <nav
-            className="flex relative gap-6 items-end self-stretch h-[88px] max-w-[1380px] max-md:flex-col max-sm:flex-row max-md:h-auto max-sm:h-auto"
+            className="flex relative gap-6 items-end self-stretch h-[88px] max-w-[1380px] max-sm:flex-row max-md:h-auto max-sm:h-auto"
             role="tablist"
             aria-label="Dataset and Release Notes Navigation"
           >

--- a/src/components/datasets/Dataset.tsx
+++ b/src/components/datasets/Dataset.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { fetchDatasetContent } from '@/utilities/data-fetching';
 import { DatasetHeader } from './DatasetHeader';
 import { DatasetContent } from './DatasetContent';
+import { UpdatedDatasetBody } from './UpdatedDatasetBody';
 import { GitHubDataset } from '@/app/page';
 import {
   processMarkdown,
@@ -13,20 +14,37 @@ import {
   extractContent
 } from './handleDatasets';
 
+import {
+  processMarkdown as updatedProcessMarkdown,
+  extractTitles as updatedExtractTitles,
+  extractH2Content as updatedExtractH2Content,
+  extractSubtitles as updatedExtractSubtitles,
+  extractH3Contents as updatedExtractH3Contents,
+  extractDataCategories as updatedExtractDataCategories,
+  extractH5Contents as updatedExtractH5Contents
+} from './handleUpdatedDatasets';
+
 interface ProcessedGitHubDataset {
-  titles: {
+  titles?: {
     id: string;
     text: string;
   }[];
-  subtitles: {
+  subtitles?: {
     id: string;
     text: string;
   }[];
-  dates: {
+  dates?: {
     id: string;
     text: string;
   }[];
-  content: string;
+  dataCategories?: {
+    id: string;
+    text: string;
+  }[];
+  content?: string;
+  h2Content?: string;
+  h3Contents?: string[];
+  h5Contents?: string[];
   name: string;
   path: string;
   type: string;
@@ -46,19 +64,39 @@ export default function DataAccessCards({ datasets, isDev }: { datasets: GitHubD
             if (!slug) {
               return null;
             }
-            const fetchedContent = await fetchDatasetContent(slug, isDev);
-            const fetchedProcessedContent = await processMarkdown(fetchedContent);
-            const titles = extractTitles(fetchedProcessedContent);
-            const subtitles = extractSubtitles(fetchedProcessedContent);
-            const dates = extractDates(fetchedProcessedContent);
-            const content = extractContent(fetchedProcessedContent);
-            return {
-              ...dataset,
-              titles,
-              subtitles,
-              dates,
-              content
-            };
+            if (slug === 'dataset_1') {
+              const fetchedContent = await fetchDatasetContent(slug, isDev);
+              const fetchedProcessedContent = await updatedProcessMarkdown(fetchedContent);
+              const titles = updatedExtractTitles(fetchedProcessedContent);
+              const h2Content = updatedExtractH2Content(fetchedProcessedContent);
+              const subtitles = updatedExtractSubtitles(fetchedProcessedContent);
+              const h3Contents = updatedExtractH3Contents(fetchedProcessedContent);
+              const dataCategories = updatedExtractDataCategories(fetchedProcessedContent);
+              const h5Contents = updatedExtractH5Contents(fetchedProcessedContent);
+              return {
+                ...dataset,
+                titles,
+                subtitles,
+                dataCategories,
+                h2Content,
+                h3Contents,
+                h5Contents
+              };
+            } else {
+              const fetchedContent = await fetchDatasetContent(slug, isDev);
+              const fetchedProcessedContent = await processMarkdown(fetchedContent);
+              const titles = extractTitles(fetchedProcessedContent);
+              const subtitles = extractSubtitles(fetchedProcessedContent);
+              const dates = extractDates(fetchedProcessedContent);
+              const content = extractContent(fetchedProcessedContent);
+              return {
+                ...dataset,
+                titles,
+                subtitles,
+                dates,
+                content
+              };
+            }
           })
         );
         setProcessedDatasets(formattedDatasets);
@@ -87,12 +125,25 @@ export default function DataAccessCards({ datasets, isDev }: { datasets: GitHubD
                   key={processedDataset?.sha}
                   className="overflow-hidden mb-2.5 p-2 w-full bg-white rounded border border-solid border-neutral-300"
                 >
-                  <DatasetHeader
-                    title={processedDataset?.titles[0].text || ''}
-                    date={processedDataset?.dates[0].text || ''}
-                    subtitle={processedDataset?.subtitles[0].text || ''}
-                  />
-                  <DatasetContent content={processedDataset?.content || ''} />
+                  {processedDataset?.name === 'dataset_1.md' ? (
+                    <UpdatedDatasetBody
+                      title={processedDataset?.titles?.[0].text || ''}
+                      subtitles={processedDataset?.subtitles || []}
+                      dataCategories={processedDataset?.dataCategories || []}
+                      h2Content={processedDataset?.h2Content || ''}
+                      h3Contents={processedDataset?.h3Contents || []}
+                      h5Contents={processedDataset?.h5Contents || []}
+                    />
+                  ) : (
+                    <>
+                      <DatasetHeader
+                        title={processedDataset?.titles?.[0].text || ''}
+                        date={processedDataset?.dates?.[0].text || ''}
+                        subtitle={processedDataset?.subtitles?.[0].text || ''}
+                      />
+                      <DatasetContent content={processedDataset?.content || ''} />
+                    </>
+                  )}
                 </article>
               ))}
             </div>

--- a/src/components/datasets/UpdatedDatasetBody.tsx
+++ b/src/components/datasets/UpdatedDatasetBody.tsx
@@ -1,0 +1,63 @@
+'use client';
+import * as React from 'react';
+
+interface UpdatedDatasetBodyProps {
+  title: string;
+  subtitles: { id: string; text: string }[];
+  dataCategories: { id: string; text: string }[];
+  h2Content: string;
+  h3Contents: string[];
+  h5Contents: string[];
+}
+
+export const UpdatedDatasetBody: React.FC<UpdatedDatasetBodyProps> = ({
+  title,
+  subtitles,
+  dataCategories,
+  h2Content,
+  h3Contents,
+  h5Contents,
+}) => {
+  return (
+    <>
+      <header className="mb-1.5 w-full max-md:max-w-full">
+        <div className="flex flex-wrap justify-between items-center w-full max-md:max-w-full">
+          <h2 className="gap-1.5 self-stretch my-auto text-lg font-bold leading-none text-sky-800 min-w-60 w-[641px] max-md:max-w-full">
+            {title}
+          </h2>
+          <section
+            className="mt-1 w-full text-sm font-semibold leading-5 text-neutral-800 max-md:max-w-full"
+            dangerouslySetInnerHTML={{ __html: h2Content }}
+          >
+          </section>
+        </div>
+      </header>
+      {h3Contents.length > 0 && h3Contents.map((h3Content, index) => (
+        <section key={subtitles[index].id} className="mb-3">
+          <section>
+            <h3 className="text-base font-semibold leading-none text-sky-800">
+              <span>{subtitles[index].text}</span>
+            </h3>
+            <section
+              className="mt-1 w-full text-sm font-semibold leading-5 text-neutral-800 max-md:max-w-full"
+              dangerouslySetInnerHTML={{ __html: h3Content }}
+            >
+            </section>
+          </section>
+          {index === h3Contents.length - 1 && h5Contents.length > 0 && h5Contents.map((h5Content, i) => (
+            <section key={dataCategories[i].id}>
+              <h4 className="mt-2.5 text-sm font-semibold leading-none text-sky-800">
+                <span>{dataCategories[i].text}</span>
+              </h4>
+              <section
+                className="mt-1 w-full text-sm font-semibold leading-5 text-neutral-800 max-md:max-w-full"
+                dangerouslySetInnerHTML={{ __html: h5Content }}
+              >
+              </section>
+            </section>
+          ))}
+        </section>
+      ))}
+    </>
+  );
+};

--- a/src/components/datasets/handleUpdatedDatasets.ts
+++ b/src/components/datasets/handleUpdatedDatasets.ts
@@ -1,0 +1,119 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkRehype from 'remark-rehype';
+import rehypeHighlight from 'rehype-highlight';
+import rehypeSlug from 'rehype-slug';
+import rehypeStringify from 'rehype-stringify';
+import { visit } from 'unist-util-visit';
+
+function rehypeCustomTheme() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (tree: any) => {
+    visit(tree, 'element', (node) => {
+      if (node.tagName === 'p') {
+        node.properties = node.properties || {};
+        node.properties.className = ['mb-3', 'max-md:max-w-full'];
+      }
+      if (node.tagName === 'a') {
+        node.properties = node.properties || {};
+        node.properties.className = ['text-[rgba(69,82,153,1)]', 'underline'];
+        node.properties.target = '_blank';
+      }
+      if (node.tagName === 'ol') {
+        node.properties = node.properties || {};
+        node.properties.className = ['list-decimal', 'list-outside', 'px-5', 'mb-2'];
+      }
+      if (node.tagName === 'ul') {
+        node.properties = node.properties || {};
+        node.properties.className = ['list-disc', 'list-outside', 'px-5', 'mb-2'];
+      }
+      if (node.tagName === 'li') {
+        node.properties = node.properties || {};
+        node.properties.className = ['mb-1'];
+      }
+    });
+  };
+}
+
+export async function processMarkdown(content: string) {
+  const result = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeCustomTheme)
+    .use(rehypeSlug)
+    .use(rehypeHighlight)
+    .use(rehypeStringify)
+    .process(content);
+
+  return result.toString();
+}
+
+function extractElements(content: string, regex: RegExp): { id: string; text: string }[] {
+  const elements: { id: string; text: string }[] = [];
+  let match;
+  
+  while ((match = regex.exec(content)) !== null) {
+    elements.push({ id: match[1], text: match[2] });
+  }
+
+  return elements;
+}
+
+export function extractTitles(content: string): { id: string; text: string }[] {
+  const regex = /<h2 id="([^"]+)"[^>]*>([^<]+)<\/h2>/g;
+
+  return extractElements(content, regex);
+}
+
+export function extractH2Content(content: string): string {
+  if (!content.includes('</h2>')) {
+		return '';
+	}
+  return content.split('</h2>')[1].trim().split('<h3')[0].trim() || '';
+}
+
+export function extractSubtitles(content: string): { id: string; text: string }[] {
+  const regex = /<h3 id="([^"]+)"[^>]*>([^<]+)<\/h3>/g;
+
+  return extractElements(content, regex);
+}
+
+// Extracts the content of all H3 headings purely
+export function extractH3Contents(content: string): string[] {
+  if (!content.includes('</h3>')) {
+		return [];
+	}
+  const h3Contents = content.split('</h3>');
+  const updatedH3Contents = [];
+  for (let i = 1; i < h3Contents.length - 1; i++) {
+    h3Contents[i] = h3Contents[i].trim().split('<h3')[0].trim();
+    updatedH3Contents.push(h3Contents[i]);
+  }
+
+  // Handle the last h3 content which contains h5 contents (TODO: A special case, not widely used)
+  const lastH3Content = h3Contents[h3Contents.length - 1].trim().split('<h5')[0].trim();
+  return [...updatedH3Contents, lastH3Content];
+}
+
+export function extractDataCategories(content: string): { id: string; text: string }[] {
+  const regex = /<h5 id="([^"]+)"[^>]*>([^<]+)<\/h5>/g;
+
+  return extractElements(content, regex);
+}
+
+// Extracts the content of all H5 headings purely
+export function extractH5Contents(content: string): string[] {
+  if (!content.includes('</h5>')) {
+		return [];
+	}
+  const h5Contents = content.split('</h5>');
+  const updatedH5Contents = [];
+  for (let i = 1; i < h5Contents.length - 1; i++) {
+    h5Contents[i] = h5Contents[i].trim().split('<h5')[0].trim();
+    updatedH5Contents.push(h5Contents[i]);
+  }
+
+  return [...updatedH5Contents, h5Contents[h5Contents.length - 1].trim()];
+}


### PR DESCRIPTION
This PR adds enhanced rendering pipeline for dataset_1 with hierarchical sections.
- Introduce UpdatedDatasetBody component supporting h2/h3/h5 structured content
- Add handleUpdatedDatasets parser (custom markdown processing & extractors)
- Conditional logic in Dataset to use new pipeline for dataset_1 (titles, subtitles, data categories, nested contents)
- Relax types to optional fields for mixed dataset formats
- Remove unused responsive flex-col class from tab nav