### PR TITLE
Switch Release Notes card order and Add dynamic refs with ResizeObserver for release notes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,7 +37,7 @@ export default function Home() {
 
         try {
           const { releases, datasets } = await fetchGitHubData(isDevEnv);
-          setReleases(releases.reverse());
+          setReleases(releases);
           setDatasets(datasets);
         } catch (error) {
           console.error(error);

--- a/src/components/datasets/Dataset.tsx
+++ b/src/components/datasets/Dataset.tsx
@@ -120,32 +120,35 @@ export default function DataAccessCards({ datasets, isDev }: { datasets: GitHubD
         <div className="flex justify-center items-start pt-5 max-w-[1260px] min-w-60 w-[960px]">
           <div className="px-2.5 pt-1.5 pb-0 min-w-60 w-[960px] max-md:max-w-full">
             <div className="w-full">
-              {processedDatasets.length > 0 && processedDatasets.map(processedDataset => (
-                <article
-                  key={processedDataset?.sha}
-                  className="overflow-hidden mb-2.5 p-2 w-full bg-white rounded border border-solid border-neutral-300"
-                >
-                  {processedDataset?.name === 'dataset_1.md' ? (
-                    <UpdatedDatasetBody
-                      title={processedDataset?.titles?.[0].text || ''}
-                      subtitles={processedDataset?.subtitles || []}
-                      dataCategories={processedDataset?.dataCategories || []}
-                      h2Content={processedDataset?.h2Content || ''}
-                      h3Contents={processedDataset?.h3Contents || []}
-                      h5Contents={processedDataset?.h5Contents || []}
-                    />
-                  ) : (
-                    <>
-                      <DatasetHeader
-                        title={processedDataset?.titles?.[0].text || ''}
-                        date={processedDataset?.dates?.[0].text || ''}
-                        subtitle={processedDataset?.subtitles?.[0].text || ''}
+              {processedDatasets.length > 0 && processedDatasets.map(processedDataset => {
+                if (!processedDataset) return null;
+                return (
+                  <article
+                    key={processedDataset.sha}
+                    className="overflow-hidden mb-2.5 p-2 w-full bg-white rounded border border-solid border-neutral-300"
+                  >
+                    {processedDataset.name === 'dataset_1.md' ? (
+                      <UpdatedDatasetBody
+                        title={processedDataset.titles?.[0].text || ''}
+                        subtitles={processedDataset.subtitles || []}
+                        dataCategories={processedDataset.dataCategories || []}
+                        h2Content={processedDataset.h2Content || ''}
+                        h3Contents={processedDataset.h3Contents || []}
+                        h5Contents={processedDataset.h5Contents || []}
                       />
-                      <DatasetContent content={processedDataset?.content || ''} />
-                    </>
-                  )}
-                </article>
-              ))}
+                    ) : (
+                      <>
+                        <DatasetHeader
+                          title={processedDataset.titles?.[0].text || ''}
+                          date={processedDataset.dates?.[0].text || ''}
+                          subtitle={processedDataset.subtitles?.[0].text || ''}
+                        />
+                        <DatasetContent content={processedDataset.content || ''} />
+                      </>
+                    )}
+                  </article>
+                );
+              })}
             </div>
             <footer className="flex gap-10 pt-3.5 pb-0 w-full border-slate-300 border-t-[3px] max-md:max-w-full" />
           </div>

--- a/src/components/release-notes/ReleaseNotes.tsx
+++ b/src/components/release-notes/ReleaseNotes.tsx
@@ -109,7 +109,7 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
         observers.forEach(observer => observer.disconnect());
       };
     }
-  }, [loading, releaseNotes, handleTabClick]);
+  }, [loading, releaseNotes]);
 
   if (loading) {
     return <div>Loading...</div>;

--- a/src/components/release-notes/ReleaseNotes.tsx
+++ b/src/components/release-notes/ReleaseNotes.tsx
@@ -112,7 +112,7 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
         observers.forEach(observer => observer.disconnect());
       };
     }
-  }, [loading, handleTabClick]);
+  }, [loading, releaseNotes, handleTabClick]);
 
   if (loading) {
     return <div>Loading...</div>;

--- a/src/components/release-notes/ReleaseNotes.tsx
+++ b/src/components/release-notes/ReleaseNotes.tsx
@@ -79,15 +79,12 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
       const observers: ResizeObserver[] = [];
       const registrations: { el: Element; handler: EventListener }[] = [];
 
-      const handler: EventListener = () => {
-        handleTabClick('dataset-updates');
-      };
-
       const attachHandlers = (container: HTMLDivElement) => {
         const wrappers = container.querySelectorAll('.dataset-updates');
         wrappers.forEach(wrapper => {
-          // Remove previous click handler before adding
-          wrapper.removeEventListener('click', handler);
+          const handler: EventListener = () => {
+            handleTabClick('dataset-updates');
+          };
           wrapper.addEventListener('click', handler);
           registrations.push({ el: wrapper, handler });
         });

--- a/src/components/release-notes/ReleaseNotes.tsx
+++ b/src/components/release-notes/ReleaseNotes.tsx
@@ -78,6 +78,7 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
     if (loading) return;
 
     const boundElements = new WeakSet<Element>();
+    const refs = mainContentRefs.current;
 
     // Use event delegation to avoid duplicate listeners
     const delegateClick = (e: Event) => {
@@ -89,7 +90,7 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
       }
     };
 
-    mainContentRefs.current.forEach(mainContentRef => {
+    refs.forEach(mainContentRef => {
       if (!mainContentRef) return;
       
       // Add single delegated listener per container
@@ -100,7 +101,7 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
     });
 
     return () => {
-      mainContentRefs.current.forEach(mainContentRef => {
+      refs.forEach(mainContentRef => {
         if (mainContentRef && boundElements.has(mainContentRef)) {
           mainContentRef.removeEventListener('click', delegateClick);
         }

--- a/src/components/release-notes/ReleaseNotes.tsx
+++ b/src/components/release-notes/ReleaseNotes.tsx
@@ -37,7 +37,8 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
   const [releaseNotes, setReleaseNotes] = useState<(ProcessedGitHubReleaseNotes | null)[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const mainContentRef = useRef<HTMLDivElement>(null);
+  // Dynamic refs: one per rendered release note container
+  const mainContentRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -75,20 +76,41 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
 
   useEffect(() => {
     if (!loading) {
-      const observer = new ResizeObserver(() => {
-        const wrapper = mainContentRef.current?.querySelector('#dataset-updates');
-        wrapper?.addEventListener('click', () => {
-          handleTabClick('dataset-updates');
+      const observers: ResizeObserver[] = [];
+      const registrations: { el: Element; handler: EventListener }[] = [];
+
+      const attachHandlers = (container: HTMLDivElement) => {
+        const wrappers = container.querySelectorAll('.dataset-updates');
+        wrappers.forEach(wrapper => {
+          // Avoid duplicate listener
+          const handler: EventListener = () => {
+            handleTabClick('dataset-updates');
+          };
+          wrapper.addEventListener('click', handler);
+          registrations.push({ el: wrapper, handler });
         });
+      };
+
+      mainContentRefs.current.forEach(mainContentRef => {
+        if (!mainContentRef) return;
+        // Initial attach
+        attachHandlers(mainContentRef);
+        const resizeObserver = new ResizeObserver(() => {
+          // Observe size changes (in case content expands / async fragments inject)
+          attachHandlers(mainContentRef);
+        });
+        resizeObserver.observe(mainContentRef);
+        observers.push(resizeObserver);
       });
-      if (mainContentRef.current) {
-        observer.observe(mainContentRef.current);
-      }
+
       return () => {
-        observer.disconnect();
+        registrations.forEach(({ el, handler }) => {
+          el.removeEventListener('click', handler);
+        });
+        observers.forEach(observer => observer.disconnect());
       };
     }
-  });
+  }, [loading, releaseNotes, handleTabClick]);
 
   if (loading) {
     return <div>Loading...</div>;
@@ -99,17 +121,23 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
       <div className="flex overflow-hidden gap-2.5 justify-center items-start w-full bg-white max-md:max-w-full">
         <div className="flex justify-center items-start pt-5 max-w-[1260px] min-w-60 w-[960px]">
           <div className="px-2.5 pt-1.5 pb-0 min-w-60 w-[960px] max-md:max-w-full">
-            {releaseNotes.length > 0 && releaseNotes.map(releaseNote => (
-              <article key={releaseNote?.sha} className="w-full mb-2.5">
-                <div ref={mainContentRef} className="p-2 w-full bg-white rounded border border-solid border-neutral-300">
-                  <ReleaseNotesHeader
-                    version={releaseNote?.titles[0].text || ''}
-                    date={releaseNote?.dates[0].text || ''}
-                  />
-                  <ReleaseNotesContent content={releaseNote?.content || ''} />
-                </div>
-              </article>
-            ))}
+            {releaseNotes.length > 0 && releaseNotes.map((releaseNote, index) => {
+              if (!releaseNote) return null;
+              return (
+                <article key={releaseNote.sha} className="w-full mb-2.5">
+                  <div
+                    ref={el => { mainContentRefs.current[index] = el; }}
+                    className="p-2 w-full bg-white rounded border border-solid border-neutral-300"
+                  >
+                    <ReleaseNotesHeader
+                      version={releaseNote.titles[0].text || ''}
+                      date={releaseNote.dates[0].text || ''}
+                    />
+                    <ReleaseNotesContent content={releaseNote.content || ''} />
+                  </div>
+                </article>
+              );
+            })}
             <footer className="flex gap-10 pt-3.5 pb-0 w-full border-slate-300 border-t-[3px] max-md:max-w-full" />
           </div>
         </div>

--- a/src/components/release-notes/ReleaseNotes.tsx
+++ b/src/components/release-notes/ReleaseNotes.tsx
@@ -75,41 +75,38 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
   }, []);
 
   useEffect(() => {
-    if (!loading) {
-      const observers: ResizeObserver[] = [];
-      const registrations: { el: Element; handler: EventListener }[] = [];
+    if (loading) return;
 
-      const attachHandlers = (container: HTMLDivElement) => {
-        const wrappers = container.querySelectorAll('.dataset-updates');
-        wrappers.forEach(wrapper => {
-          const handler: EventListener = () => {
-            handleTabClick('dataset-updates');
-          };
-          wrapper.addEventListener('click', handler);
-          registrations.push({ el: wrapper, handler });
-        });
-      };
+    const boundElements = new WeakSet<Element>();
 
+    // Use event delegation to avoid duplicate listeners
+    const delegateClick = (e: Event) => {
+      const target = e.target as HTMLElement | null;
+      if (!target) return;
+      const clickable = target.closest('.dataset-updates');
+      if (clickable) {
+        handleTabClick('dataset-updates');
+      }
+    };
+
+    mainContentRefs.current.forEach(mainContentRef => {
+      if (!mainContentRef) return;
+      
+      // Add single delegated listener per container
+      if (!boundElements.has(mainContentRef)) {
+        mainContentRef.addEventListener('click', delegateClick);
+        boundElements.add(mainContentRef);
+      }
+    });
+
+    return () => {
       mainContentRefs.current.forEach(mainContentRef => {
-        if (!mainContentRef) return;
-        // Initial attach
-        attachHandlers(mainContentRef);
-        const resizeObserver = new ResizeObserver(() => {
-          // Observe size changes (in case content expands / async fragments inject)
-          attachHandlers(mainContentRef);
-        });
-        resizeObserver.observe(mainContentRef);
-        observers.push(resizeObserver);
+        if (mainContentRef && boundElements.has(mainContentRef)) {
+          mainContentRef.removeEventListener('click', delegateClick);
+        }
       });
-
-      return () => {
-        registrations.forEach(({ el, handler }) => {
-          el.removeEventListener('click', handler);
-        });
-        observers.forEach(observer => observer.disconnect());
-      };
-    }
-  }, [loading, releaseNotes]);
+    };
+  }, [loading]);
 
   if (loading) {
     return <div>Loading...</div>;

--- a/src/components/release-notes/ReleaseNotes.tsx
+++ b/src/components/release-notes/ReleaseNotes.tsx
@@ -112,7 +112,7 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
         observers.forEach(observer => observer.disconnect());
       };
     }
-  }, [loading, releaseNotes, handleTabClick]);
+  }, [loading, handleTabClick]);
 
   if (loading) {
     return <div>Loading...</div>;

--- a/src/components/release-notes/ReleaseNotes.tsx
+++ b/src/components/release-notes/ReleaseNotes.tsx
@@ -79,13 +79,15 @@ export default function ReleaseNotes({ releases, isDev, handleTabClick }: {
       const observers: ResizeObserver[] = [];
       const registrations: { el: Element; handler: EventListener }[] = [];
 
+      const handler: EventListener = () => {
+        handleTabClick('dataset-updates');
+      };
+
       const attachHandlers = (container: HTMLDivElement) => {
         const wrappers = container.querySelectorAll('.dataset-updates');
         wrappers.forEach(wrapper => {
-          // Avoid duplicate listener
-          const handler: EventListener = () => {
-            handleTabClick('dataset-updates');
-          };
+          // Remove previous click handler before adding
+          wrapper.removeEventListener('click', handler);
           wrapper.addEventListener('click', handler);
           registrations.push({ el: wrapper, handler });
         });

--- a/src/components/release-notes/handleReleaseNotes.ts
+++ b/src/components/release-notes/handleReleaseNotes.ts
@@ -19,7 +19,7 @@ function rehypeCustomTheme() {
         node.properties = node.properties || {};
         node.properties.className = ['text-[rgba(69,82,153,1)]', 'underline'];
         if (node.properties.href === 'dataset-updates') {
-          node.properties.id = node.properties.href;
+          node.properties.className.push(node.properties.href);
           node.properties.href = 'javascript:void(0);';
         } else {
           node.properties.target = '_blank';

--- a/src/utilities/data-fetching.ts
+++ b/src/utilities/data-fetching.ts
@@ -49,7 +49,7 @@ async function fetchGitHubData(isDev: boolean = false) {
         }
 
         const releaseNotesData = await releaseNotesResponse.json();
-        const releaseNotes = releaseNotesData.filter((item: { type: string; name: string }) => item.type === 'file' && item.name.endsWith('.md'));
+        const releaseNotes = releaseNotesData.filter((item: { type: string; name: string }) => item.type === 'file' && item.name.endsWith('.md')).reverse();
 
         return {
           ...release,


### PR DESCRIPTION
This pull request refactors how release notes and datasets are rendered and handled, focusing on improving robustness, event handling, and code clarity. The main changes include switching to dynamic refs for release notes containers, enhancing event listener attachment for dataset updates, and ensuring null safety when rendering lists. Additionally, there are minor adjustments to data fetching and theming logic.

**Release Notes Rendering and Event Handling:**
* Switched from a single `mainContentRef` to an array of dynamic refs (`mainContentRefs`) for each release note container, enabling more granular DOM event management.
* Refactored the event listener logic to attach click handlers to all `.dataset-updates` elements within each release note container, ensuring proper cleanup and avoiding duplicate listeners.
* Updated rendering to use the new dynamic refs and added null checks when mapping over `releaseNotes`, improving stability and preventing runtime errors.

**Dataset Rendering Improvements:**
* Added null safety checks when rendering `processedDatasets` and removed unnecessary optional chaining, making the code more robust and readable.

**Data Fetching and Theming Adjustments:**
* Changed the release notes fetching logic to reverse the order of release notes in the data utility, rather than in the component, ensuring consistent ordering. [[1]](diffhunk://#diff-38a2f1e45ddfe055ec17f12d6defdfb1a709a98f4b37a9b7c76060a4dd5ceacbL52-R52) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL40-R40)
* Updated the custom theme processor to add the class name for dataset update links instead of setting an ID, aligning with the new event handling approach.