### PR TITLE
Add build-push-image yml file

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -11,7 +11,7 @@ on:
         type: boolean
         description: Ignore vulnerabilities if they are found
         required: true
-        default: false
+        default: true
 
 jobs:
     build-and-push:

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,102 @@
+name: Build and Push Docker image to ECR
+
+permissions: 
+  contents: write
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      ignore_trivy_scan:
+        type: boolean
+        description: Ignore vulnerabilities if they are found
+        required: true
+        default: false
+
+jobs:
+    build-and-push:
+        name: Build and push image to ECR
+        runs-on: ubuntu-latest
+        env:
+            ECR_REPOSITORY: ccdi-cbioportal-backend
+
+        steps:
+          - name: Checkout repository
+            uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5   #2.7.0 
+
+          
+          - name: Set Image Tag
+            env:
+                BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+            run: |
+                # Get all tags for the repo and find the latest tag for the branch being built
+                git fetch --tags --force --quiet
+                tag=$(git tag -l $BRANCH_NAME* | sort -V | tail -1)
+
+                if  [ ! -z "$tag" ];
+                then
+                    # Increment the build number if a tag is found
+                    build_num=$(echo "${tag##*.}")
+                    build_num=$((build_num+1))
+                    echo "IMAGE_TAG=$BRANCH_NAME.$build_num" >> $GITHUB_ENV
+                else
+                    # If no tag is found create a new tag name
+                    build_num=1
+                    echo "IMAGE_TAG=$BRANCH_NAME.$build_num" >> $GITHUB_ENV
+                fi
+
+          - name: Set up Docker Buildx
+            uses: docker/setup-buildx-action@v2
+
+          - name: Build Docker image
+            run: |
+                docker buildx build --no-cache --output type=docker --platform linux/amd64 --build-arg NEXT_PUBLIC_CONTENT_API_TOKEN=${{ secrets.NEXT_PUBLIC_CONTENT_API_TOKEN }} -t ${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }} .
+
+          - name: Set Trivy exit code
+            run: |
+                if  [[ ${{ inputs.ignore_trivy_scan }} == true ]];
+                then
+                    echo 'TRIVY_EXIT_CODE=0' >> $GITHUB_ENV
+                else
+                    echo 'TRIVY_EXIT_CODE=1' >> $GITHUB_ENV
+                fi
+
+          - name: Run Trivy vulnerability scanner
+            id: trivy-scan
+            uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5     # v0.30.0
+            with:
+                image-ref: '${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}'
+                format: 'table'
+                exit-code: '${{ env.TRIVY_EXIT_CODE }}'
+                ignore-unfixed: true
+                severity: 'CRITICAL,HIGH'
+
+          - name: Create Git tag for Image
+            run: |
+                git config user.name "GitHub Actions"
+                git config user.email "github-actions@users.noreply.github.com"
+                git tag ${{ env.IMAGE_TAG }}
+                git push origin ${{ env.IMAGE_TAG }}
+        
+          - name: Authenticate to OIDC
+            uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502     # v4.0.2
+            with:
+                role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+                aws-region: ${{ secrets.AWS_REGION }}
+                role-session-name: ${{ github.actor }}
+          
+          - name: Login to Amazon ECR
+            id: login-aws-ecr
+            uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076     # v2.0.1
+
+          - name: Push Docker image to ECR
+            id: push-image
+            env:
+                ECR_REGISTRY: ${{ steps.login-aws-ecr.outputs.registry }}
+            run: |
+                docker tag  $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+                docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+          - name: "Docker image successfully pushed with tag: ${{ env.IMAGE_TAG }}"
+            run: |
+              echo "The Docker image has been successfully pushed with the tag: ${{ env.IMAGE_TAG }}"

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -18,7 +18,7 @@ jobs:
         name: Build and push image to ECR
         runs-on: ubuntu-latest
         env:
-            ECR_REPOSITORY: ccdi-cbioportal-backend
+            ECR_REPOSITORY: ccdi-cbioportal-content-ui
 
         steps:
           - name: Checkout repository


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building, scanning, tagging, and pushing Docker images to AWS ECR. The workflow also integrates vulnerability scanning and dynamic tagging based on branch and build number.

**CI/CD Automation:**

* Added `.github/workflows/build-push-image.yml` to automate building and pushing Docker images to ECR, including steps for checking out the repository, setting up Docker Buildx, and pushing the image to AWS ECR.
* Implemented dynamic Docker image tagging based on the current branch and incremented build numbers, and automatically creates and pushes corresponding Git tags.

**Security and Quality:**

* Integrated Trivy vulnerability scanning into the workflow, with an option to ignore scan failures via a workflow input parameter.

**AWS Integration:**

* Configured OIDC authentication and ECR login using GitHub Actions for secure and automated AWS access.