### PR TITLE
Add Env tier detection

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -42,7 +42,9 @@ const About: FC = () => {
   useEffect(() => {
     const loadData = async () => {
       if (typeof window !== 'undefined') {
-        const isDevEnv = (process.env.NODE_ENV === 'development') || !!window.location.search;
+        const tierNameArr = window.location.hostname.split('.')[0].split('-');
+        const isLocalEnv = process.env.NODE_ENV === 'development';
+        const isDevEnv = isLocalEnv || tierNameArr.includes('dev') || tierNameArr.includes('qa');
 
         try {
           const { aboutFiles, content } = await fetchAboutData(isDevEnv);

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -2,6 +2,7 @@
 
 import { FC, useState, useEffect, useRef } from 'react';
 import { fetchAboutData } from '@/utilities/data-fetching';
+import { isDevEnv } from '@/utilities/environment';
 import Image from 'next/image';
 import { AboutContent } from '@/components/about/AboutContent';
 import {
@@ -42,12 +43,8 @@ const About: FC = () => {
   useEffect(() => {
     const loadData = async () => {
       if (typeof window !== 'undefined') {
-        const tierNameArr = window.location.hostname.split('.')[0].split('-');
-        const isLocalEnv = process.env.NODE_ENV === 'development';
-        const isDevEnv = isLocalEnv || tierNameArr.includes('dev') || tierNameArr.includes('qa');
-
         try {
-          const { aboutFiles, content } = await fetchAboutData(isDevEnv);
+          const { aboutFiles, content } = await fetchAboutData(isDevEnv(window.location.hostname));
           const formattedAbouts = await Promise.all(
             aboutFiles.map(async (fetchedAbout: GitHubAbout) => {
               const fetchedProcessedContent = await processMarkdown(content);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { fetchGitHubData } from '@/utilities/data-fetching';
+import { isDevEnv as checkIsDevEnv } from '@/utilities/environment';
 import DatasetAndReleaseNotes from '@/components/DatasetAndReleaseNotes';
 
 export interface GitHubRelease {
@@ -32,9 +33,7 @@ export default function Home() {
   useEffect(() => {
     const loadData = async () => {
       if (typeof window !== 'undefined') {
-        const tierNameArr = window.location.hostname.split('.')[0].split('-');
-        const isLocalEnv = process.env.NODE_ENV === 'development';
-        const isDevEnv = isLocalEnv || tierNameArr.includes('dev') || tierNameArr.includes('qa');
+        const isDevEnv = checkIsDevEnv(window.location.hostname);
         setIsDev(isDevEnv);
 
         try {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,9 @@ export default function Home() {
   useEffect(() => {
     const loadData = async () => {
       if (typeof window !== 'undefined') {
-        const isDevEnv = (process.env.NODE_ENV === 'development') || !!window.location.search;
+        const tierNameArr = window.location.hostname.split('.')[0].split('-');
+        const isLocalEnv = process.env.NODE_ENV === 'development';
+        const isDevEnv = isLocalEnv || tierNameArr.includes('dev') || tierNameArr.includes('qa');
         setIsDev(isDevEnv);
 
         try {

--- a/src/utilities/environment.ts
+++ b/src/utilities/environment.ts
@@ -1,0 +1,7 @@
+export const isDevEnv = (hostname: string): boolean => {
+  if (!hostname) return false;
+  const firstPart: string = hostname.includes('.') ? hostname.split('.')[0] : hostname;
+  const tierNameArr: string[] = firstPart.split('-');
+  const isLocalEnv = process.env.NODE_ENV === 'development';
+  return isLocalEnv || tierNameArr.includes('dev') || tierNameArr.includes('qa');
+};


### PR DESCRIPTION
This pull request updates the logic for determining the development environment in both the `About` and `Home` page components. The main change is a more robust check for dev and QA environments based on the hostname, improving how environment-specific data is loaded.

Environment detection improvements:

* Updated the `isDevEnv` logic in `src/app/about/page.tsx` and `src/app/page.tsx` to check if the hostname includes `dev` or `qa`, in addition to the traditional local development check. This ensures the app correctly identifies dev and QA tiers even when deployed, not just in local development. [[1]](diffhunk://#diff-d38aaae18142756b8b93ec0043df16888550dfded455e182cc0e4a81eb8286e2L45-R47) [[2]](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bL35-R37)