### PR TITLE
Add third section support to data-using page

### DIFF
--- a/src/app/data-using/page.tsx
+++ b/src/app/data-using/page.tsx
@@ -113,7 +113,7 @@ const DataUsing: FC = () => {
             <h2 className="font-[Poppins] font-normal text-[25px] lg:text-[22px] leading-[26px] tracking-[-0.05px] lg:tracking-[-0.044px] text-[#05555c] w-full">
               {title.text}
             </h2>
-            {processedDataUsing.contents[index]?.split('\n').filter(content => content.trim() !== '').map((content, i) => (
+            {processedDataUsing.contents[index].split('\n').filter(content => content.trim() !== '').map((content, i) => (
               <div
                 key={`${title.id}-${i}`}
                 className={`flex flex-col gap-5 lg:gap-6 items-start max-w-full lg:max-w-[984px] w-full ${index === 1 && i === 0 ? 'mb-[15px]' : ''}`}

--- a/src/app/data-using/page.tsx
+++ b/src/app/data-using/page.tsx
@@ -10,6 +10,7 @@ import {
   extractTitles,
   extractSection1Content,
   extractSection2Content,
+  extractSection3Content,
 } from '@/components/data-using/handleDataUsing';
 import cBioStudyClinicalData from '../../../assets/data-using/cBioStudyClinicalData.png';
 import ccdiExploreDashboard from '../../../assets/data-using/ccdiExploreDashboard.png';
@@ -42,10 +43,11 @@ const DataUsing: FC = () => {
             const titles = extractTitles(fetchedProcessedContent);
             const section1Content = extractSection1Content(fetchedProcessedContent);
             const section2Content = extractSection2Content(fetchedProcessedContent);
+            const section3Content = extractSection3Content(fetchedProcessedContent);
             const formattedDataUsing = {
               ...dataUsingFile,
               titles,
-              contents: [section1Content, section2Content],
+              contents: [section1Content, section2Content, section3Content],
             };
             setProcessedDataUsing(formattedDataUsing);
           }
@@ -111,13 +113,13 @@ const DataUsing: FC = () => {
             <h2 className="font-[Poppins] font-normal text-[25px] lg:text-[22px] leading-[26px] tracking-[-0.05px] lg:tracking-[-0.044px] text-[#05555c] w-full">
               {title.text}
             </h2>
-            {processedDataUsing.contents[index].split('\n').filter(content => content.trim() !== '').map((content, i) => (
+            {processedDataUsing.contents[index]?.split('\n').filter(content => content.trim() !== '').map((content, i) => (
               <div
                 key={`${title.id}-${i}`}
-                className={`flex flex-col gap-5 lg:gap-6 items-start max-w-full lg:max-w-[984px] w-full ${index === 0 && i === 0 ? 'mb-[15px]' : ''}`}
+                className={`flex flex-col gap-5 lg:gap-6 items-start max-w-full lg:max-w-[984px] w-full ${index === 1 && i === 0 ? 'mb-[15px]' : ''}`}
               >
-                <DataUsingContent content={content} isCitationBox={index === 1 && i === 1} />
-                {index === 0 && (
+                <DataUsingContent content={content} isCitationBox={index === 2 && i === 1} />
+                {index === 1 && (
                   <div className="flex flex-col gap-5 lg:gap-[20px] items-center w-full">
                     <div className="relative w-full max-w-[335px] sm:max-w-[504px] lg:max-w-[656px] xl:max-w-[656px] 2xl:max-w-[656px] h-auto">
                       <div

--- a/src/app/data-using/page.tsx
+++ b/src/app/data-using/page.tsx
@@ -28,6 +28,9 @@ interface ProcessedGitHubDataUsing {
   sha?: string;
 }
 
+const HOW_TO = 1;
+const CITING = 2;
+
 const DataUsing: FC = () => {
   const [processedDataUsing, setProcessedDataUsing] = useState<ProcessedGitHubDataUsing | null>(null);
   const [loading, setLoading] = useState(true);
@@ -116,10 +119,10 @@ const DataUsing: FC = () => {
             {processedDataUsing.contents[index].split('\n').filter(content => content.trim() !== '').map((content, i) => (
               <div
                 key={`${title.id}-${i}`}
-                className={`flex flex-col gap-5 lg:gap-6 items-start max-w-full lg:max-w-[984px] w-full ${index === 1 && i === 0 ? 'mb-[15px]' : ''}`}
+                className={`flex flex-col gap-5 lg:gap-6 items-start max-w-full lg:max-w-[984px] w-full ${index === HOW_TO && i === 0 ? 'mb-[15px]' : ''}`}
               >
-                <DataUsingContent content={content} isCitationBox={index === 2 && i === 1} />
-                {index === 1 && (
+                <DataUsingContent content={content} isCitationBox={index === CITING && i === 1} />
+                {index === HOW_TO && (
                   <div className="flex flex-col gap-5 lg:gap-[20px] items-center w-full">
                     <div className="relative w-full max-w-[335px] sm:max-w-[504px] lg:max-w-[656px] xl:max-w-[656px] 2xl:max-w-[656px] h-auto">
                       <div

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,3 +41,7 @@ body {
 #about .contact-section a {
   overflow-wrap: break-word; /* ensure long emails/urls wrap */
 }
+/* Data Use Expectations section responsive adjustments */
+#data-using > div.flex.flex-col.gap-5 > div.flex.flex-col.gap-5 > div > p > a {
+  overflow-wrap: break-word; /* ensure long emails/urls wrap */
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -36,12 +36,3 @@ body {
 .about-header-image img {
   height: 214px;
 }
-
-/* Contact section responsive adjustments */
-#about .contact-section a {
-  overflow-wrap: break-word; /* ensure long emails/urls wrap */
-}
-/* Data Use Expectations section responsive adjustments */
-#data-using > div.flex.flex-col.gap-5 > div.flex.flex-col.gap-5 > div > p > a {
-  overflow-wrap: break-word; /* ensure long emails/urls wrap */
-}

--- a/src/components/about/handleAbout.ts
+++ b/src/components/about/handleAbout.ts
@@ -32,6 +32,9 @@ function rehypeCustomTheme() {
           'text-[rgba(69,82,153,1)]',
           'underline'
         ];
+        if (node.properties.href.includes('mailto:')) {
+          LINK_CLASSES.push('wrap-break-word');
+        }
         node.properties = node.properties || {};
         node.properties.className = LINK_CLASSES;
         node.properties.target = '_blank';

--- a/src/components/data-using/handleDataUsing.ts
+++ b/src/components/data-using/handleDataUsing.ts
@@ -77,5 +77,5 @@ export function extractSection3Content(content: string): string {
 	if (!content.includes('</h2>')) {
 		return '';
 	}
-  return content.split('</h2>')[3].trim() || '';
+  return content.split('</h2>')[3].trim().split('<h2')[0].trim() || '';
 }

--- a/src/components/data-using/handleDataUsing.ts
+++ b/src/components/data-using/handleDataUsing.ts
@@ -53,6 +53,12 @@ function extractElements(content: string, regex: RegExp): { id: string; text: st
   return elements;
 }
 
+export function extractTitles(content: string): { id: string; text: string }[] {
+  const regex = /<h2 id="([^"]+)"[^>]*>([^<]+)<\/h2>/g;
+
+  return extractElements(content, regex);
+}
+
 export function extractSection1Content(content: string): string {
   if (!content.includes('</h2>')) {
 		return '';
@@ -60,15 +66,16 @@ export function extractSection1Content(content: string): string {
   return content.split('</h2>')[1].trim().split('<h2')[0].trim() || '';
 }
 
-export function extractTitles(content: string): { id: string; text: string }[] {
-  const regex = /<h2 id="([^"]+)"[^>]*>([^<]+)<\/h2>/g;
-
-  return extractElements(content, regex);
+export function extractSection2Content(content: string): string {
+  if (!content.includes('</h2>')) {
+		return '';
+	}
+  return content.split('</h2>')[2].trim().split('<h2')[0].trim() || '';
 }
 
-export function extractSection2Content(content: string): string {
+export function extractSection3Content(content: string): string {
 	if (!content.includes('</h2>')) {
 		return '';
 	}
-  return content.split('</h2>')[2] || '';
+  return content.split('</h2>')[3] || '';
 }

--- a/src/components/data-using/handleDataUsing.ts
+++ b/src/components/data-using/handleDataUsing.ts
@@ -77,5 +77,5 @@ export function extractSection3Content(content: string): string {
 	if (!content.includes('</h2>')) {
 		return '';
 	}
-  return content.split('</h2>')[3] || '';
+  return content.split('</h2>')[3].trim() || '';
 }

--- a/src/components/data-using/handleDataUsing.ts
+++ b/src/components/data-using/handleDataUsing.ts
@@ -20,6 +20,9 @@ function rehypeCustomTheme() {
           'text-[rgba(69,82,153,1)]',
           'underline'
         ];
+        if (node.properties.href.includes('mailto:')) {
+          LINK_CLASSES.push('wrap-break-word');
+        }
         node.properties = node.properties || {};
         node.properties.className = LINK_CLASSES;
         node.properties.target = '_blank';


### PR DESCRIPTION
This pull request updates the data extraction and rendering logic for the Data Using page to support a third content section, and improves the robustness and responsiveness of the UI. The main changes are the addition of a new extraction function, updates to how content is split and displayed, and a minor CSS tweak for better link wrapping.

**Data extraction and processing improvements:**

* Added a new function `extractSection3Content` in `handleDataUsing.ts` to extract a third section of content, and refactored `extractSection2Content` for consistency. The `extractTitles` function was also moved for clarity.
* Updated `page.tsx` to use the new `extractSection3Content` function and include the third section in the `contents` array, ensuring all three sections are processed and rendered. [[1]](diffhunk://#diff-e17573e13cc5bb4d612d16532b6ec951566bce387a887f275d885ff5d984269bR13) [[2]](diffhunk://#diff-e17573e13cc5bb4d612d16532b6ec951566bce387a887f275d885ff5d984269bR46-R50)

**Rendering logic adjustments:**

* Modified the rendering loop in `page.tsx` to safely handle the new third section, update the logic for when to display certain UI elements, and fix which section triggers special rendering cases.

**UI/Styling improvements:**

* Added a CSS rule in `globals.css` to ensure long links in the Data Use Expectations section wrap properly on all screen sizes.