### PR TITLE
Swap the order of the Application Release Notes and Dataset Updates tabs

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,12 +6,12 @@ import Dataset from '@/components/datasets/Dataset';
 
 const tabs = [
   {
-    id: 'application-release-notes',
-    label: 'Application Release Notes'
-  },
-  {
     id: 'dataset-updates',
     label: 'Dataset Updates'
+  },
+  {
+    id: 'application-release-notes',
+    label: 'Application Release Notes'
   }
 ];
 
@@ -79,8 +79,8 @@ export default function Home() {
           </div>
         </section>
         <section>
-          {activeTabId === tabs[0].id && <ReleaseNotes handleTabClick={handleTabClick} />}
-          {activeTabId === tabs[1].id && <Dataset />}
+          {activeTabId === tabs[0].id && <Dataset />}
+          {activeTabId === tabs[1].id && <ReleaseNotes handleTabClick={handleTabClick} />}
         </section>
       </div>
     </main>


### PR DESCRIPTION
This pull request updates the tab order and corresponding content rendering on the home page to display the "Dataset Updates" tab first, followed by the "Application Release Notes" tab. The changes ensure that the correct content is shown for each tab based on the new order.

Tab order and content rendering updates:

* Reordered the `tabs` array in `src/app/page.tsx` so that "Dataset Updates" appears before "Application Release Notes".
* Updated the tab content rendering logic to match the new tab order, displaying the `Dataset` component for the first tab and the `ReleaseNotes` component for the second tab.